### PR TITLE
2.24 compliance

### DIFF
--- a/_public.php
+++ b/_public.php
@@ -16,7 +16,6 @@ if (!defined('DC_RC_PATH')) {
 }
 
 use ArrayObject;
-use dcCore;
 
 \l10n::set(dirname(__FILE__) . '/locales/' . \dcCore::app()->lang . '/main');
 
@@ -26,7 +25,7 @@ use dcCore;
 \dcCore::app()->tpl->addValue('editorialUserColors', [__NAMESPACE__ . '\tplEditorialTheme', 'editorialUserColors']);
 \dcCore::app()->tpl->addValue('editorialSocialLinks', [__NAMESPACE__ . '\tplEditorialTheme', 'editorialSocialLinks']);
 
-\dcCore::app()->addBehavior('templateBeforeBlockV2', [__NAMESPACE__ . behaviorsFeaturedPost::class, 'templateBeforeBlock']);
+\dcCore::app()->addBehavior('templateBeforeBlockV2', [behaviorsFeaturedPost::class, 'templateBeforeBlock']);
 
 class featuredPostTpl
 {
@@ -190,5 +189,7 @@ class behaviorsFeaturedPost
             "\$params['sql'] .= \"AND P.post_url != '" . urldecode($featuredPostURL) . "' \";\n" .
                 "?>\n";
         }
+
+        return '';
     }
 }

--- a/tpl/home-featured-post.html
+++ b/tpl/home-featured-post.html
@@ -1,21 +1,20 @@
 <div class="posts">
-        <!-- # First page -->
-        <tpl:SysIf current_mode="default">
-            <tpl:Entries lastn="1" featured_url="1">
-                {{tpl:include src="_entry-featured.html"}}
-            </tpl:Entries>
-            
-            <tpl:Entries featured_url="0">
-                {{tpl:include src="_entry-short.html"}}
-            </tpl:Entries>
-        </tpl:SysIf>
-        <!-- # Next pages -->
-        <tpl:SysIf current_mode="!default">
-            <tpl:Entries featured_url="0">
-                {{tpl:include src="_entry-short.html"}}
-            </tpl:Entries>
-        </tpl:SysIf>
-    </tpl:Entries>
+    <!-- # First page -->
+    <tpl:SysIf current_mode="default">
+        <tpl:Entries lastn="1" featured_url="1">
+            {{tpl:include src="_entry-featured.html"}}
+        </tpl:Entries>
+
+        <tpl:Entries featured_url="0">
+            {{tpl:include src="_entry-short.html"}}
+        </tpl:Entries>
+    </tpl:SysIf>
+    <!-- # Next pages -->
+    <tpl:SysIf current_mode="!default">
+        <tpl:Entries featured_url="0">
+            {{tpl:include src="_entry-short.html"}}
+        </tpl:Entries>
+    </tpl:SysIf>
 </div>
 
 <tpl:Entries featured_url="0">


### PR DESCRIPTION
- Wrong use of namespace for templateBeforeBlockV2 behaviour declaration
- templateBeforeBlockV2 behaviour callback must return a string, in any case
- One </tpl:Entries> without any opening <tpl:Entries> in home-featured-post.html template